### PR TITLE
 fix: wrong Y scale when max value of data is less than 5 ticks

### DIFF
--- a/src/TimeGraph.js
+++ b/src/TimeGraph.js
@@ -23,6 +23,7 @@ const xTickSize = {
 const numberFormat = d3.format(',d')
 const DEFAULT_MARGIN = { left: 80, right: 30, top: 50, bottom: 25 }
 const STACK_LIMIT = 10
+const DEFAULT_Y_AXIS_TICKS = 5
 
 
 export const aggregation = {
@@ -247,11 +248,11 @@ export default class TimeGraph extends React.Component {
   maxYTicks() {
     const maxValue = Math.max.apply(Math, Object.values(this.props.data).map(obj => obj.c))
 
-    if (maxValue < 5) {
+    if (maxValue < DEFAULT_Y_AXIS_TICKS) {
       return maxValue
     }
 
-    return 5
+    return DEFAULT_Y_AXIS_TICKS
   }
 
   preProcess(data, timeBounds) {

--- a/src/TimeGraph.js
+++ b/src/TimeGraph.js
@@ -231,10 +231,9 @@ export default class TimeGraph extends React.Component {
       .tickFormat(xFormatter)
       .ticks(maxTicks)
 
-
     const yAxis = d3.axisLeft(y)
       .tickFormat(yFormatter)
-      .ticks(5)
+      .ticks(this.maxYTicks())
       .tickSize(-width + margin.right + margin.left)
 
     const lineFunc = d3.line()
@@ -243,6 +242,16 @@ export default class TimeGraph extends React.Component {
       .curve(d3.curveStep)
 
     return { lineFunc: lineFunc, scale: { x: x, y: y }, axis: { x: xAxis, y: yAxis } }
+  }
+
+  maxYTicks() {
+    const maxValue = Math.max.apply(Math, Object.values(this.props.data).map(obj => obj.c))
+
+    if (maxValue < 5) {
+      return maxValue
+    }
+
+    return 5
   }
 
   preProcess(data, timeBounds) {


### PR DESCRIPTION
To maintain the default scale of 5 ticks, it finds the max value for the data and if it's less than the default, use the new value.